### PR TITLE
TASK-7: 인기검색어 자동갱신 스케쥴러 작업

### DIFF
--- a/search-api/build.gradle
+++ b/search-api/build.gradle
@@ -10,5 +10,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
     // Feign client
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:3.1.5'
-
+    // ShedLock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.2.0'
 }

--- a/search-api/src/main/java/com/james/api/SearchApiApplication.java
+++ b/search-api/src/main/java/com/james/api/SearchApiApplication.java
@@ -1,9 +1,13 @@
 package com.james.api;
 
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
 @EnableFeignClients
 @SpringBootApplication
 public class SearchApiApplication {

--- a/search-api/src/main/java/com/james/api/configuration/ChedLockConfiguration.java
+++ b/search-api/src/main/java/com/james/api/configuration/ChedLockConfiguration.java
@@ -1,0 +1,17 @@
+package com.james.api.configuration;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class ChedLockConfiguration {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource){
+        return new JdbcTemplateLockProvider(dataSource);
+    }
+}

--- a/search-api/src/main/java/com/james/api/scheduler/ScheduleUpdatePopularKeyword.java
+++ b/search-api/src/main/java/com/james/api/scheduler/ScheduleUpdatePopularKeyword.java
@@ -1,0 +1,49 @@
+package com.james.api.scheduler;
+
+import com.james.core.entity.History;
+import com.james.core.repository.HistoryRepository;
+import com.james.core.repository.SearchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScheduleUpdatePopularKeyword {
+
+    private final HistoryRepository historyRepository;
+    private final SearchRepository searchRepository;
+
+    @Scheduled(cron = "0 */5 * * * *")
+    @SchedulerLock(name = "testShedLockJob", lockAtLeastFor = "PT4M59S", lockAtMostFor = "PT4M59S")
+    public void deleteExpiredHistoryAndUpdateSearchCallCount() {
+        
+        LocalDateTime expiredTime = LocalDateTime.now().minusMinutes(15L);
+        List<History> expiredHistoryList = historyRepository.findByCreatedAtBefore(expiredTime);
+
+        if (expiredHistoryList.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Long> countOfSearchToDecrease = new HashMap<>();
+        for (History history : expiredHistoryList) {
+            Long searchId = history.getSearch().getId();
+            Long count = countOfSearchToDecrease.containsKey(searchId) ? countOfSearchToDecrease.get(searchId) + 1L : 1L;
+            countOfSearchToDecrease.put(searchId, count);
+        }
+
+        historyRepository.deleteAll(expiredHistoryList);
+
+        for(Map.Entry<Long, Long> entry : countOfSearchToDecrease.entrySet()) {
+            searchRepository.decreaseCallCount(entry.getKey(), entry.getValue());
+        }
+    }
+}

--- a/search-api/src/main/java/com/james/api/service/SearchService.java
+++ b/search-api/src/main/java/com/james/api/service/SearchService.java
@@ -7,10 +7,12 @@ import com.james.api.feign.SearchKakaoFeignClient;
 import com.james.api.feign.SearchNaverFeignClient;
 import com.james.api.feign.dto.response.GetSearchKakaoBlogResponseDto;
 import com.james.api.feign.dto.response.GetSearchNaverBlogResponseDto;
+import com.james.core.entity.History;
 import com.james.core.entity.Search;
 import com.james.core.exception.NaverApiPageIsTooLargeException;
 import com.james.core.exception.NoResponseFromServerException;
 import com.james.core.exception.NotFoundSearchException;
+import com.james.core.repository.HistoryRepository;
 import com.james.core.repository.SearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
@@ -38,12 +40,13 @@ public class SearchService {
     private String secret;
 
     private final SearchRepository searchRepository;
+    private final HistoryRepository historyRepository;
     private final SearchKakaoFeignClient searchKakaoFeignClient;
     private final SearchNaverFeignClient searchNaverFeignClient;
 
     public Page<GetSearchBlogResponseDto> getBlogList(String keyword, SortEnum sort, Integer page, Integer size) {
 
-        saveHistory(keyword);
+        saveHistory(InsertOrUpdateSearch(keyword));
 
         String authorization = "KakaoAK " + apiKey;
         List<GetSearchBlogResponseDto> documentList = new ArrayList<>();
@@ -73,24 +76,31 @@ public class SearchService {
         return new PageImpl<>(documentList, PageRequest.of(page, size), totalCount);
     }
 
-    private void saveHistory(String keyword) {
+    private Search InsertOrUpdateSearch(String keyword) {
 
         Search search = searchRepository.findByKeyword(keyword);
 
         if (search != null) {
             searchRepository.increaseCallCount(search.getId());
-            return;
+            return search;
         }
 
         search = new Search(keyword);
         try {
-            searchRepository.save(search);
+            search = searchRepository.save(search);
         } catch (DataIntegrityViolationException dataIntegrityViolationException) {
             search = searchRepository.findByKeyword(keyword);
             if (search == null)
                 throw new NotFoundSearchException();
             searchRepository.increaseCallCount(search.getId());
         }
+        return search;
+    }
+
+    private void saveHistory(Search search){
+        History history = new History();
+        history.setSearch(search);
+        historyRepository.save(history);
     }
 
     public List<GetPopularKeywordListResponseDto> getPopularKeywordList() {

--- a/search-api/src/main/java/com/james/api/service/SearchService.java
+++ b/search-api/src/main/java/com/james/api/service/SearchService.java
@@ -85,9 +85,8 @@ public class SearchService {
             return search;
         }
 
-        search = new Search(keyword);
         try {
-            search = searchRepository.save(search);
+            search = searchRepository.save(new Search(keyword));
         } catch (DataIntegrityViolationException dataIntegrityViolationException) {
             search = searchRepository.findByKeyword(keyword);
             if (search == null)

--- a/search-api/src/main/resources/application.yaml
+++ b/search-api/src/main/resources/application.yaml
@@ -1,16 +1,22 @@
 spring:
   jpa:
-    show-sql: true
+    show-sql: false
     database: h2
     properties:
       hibernate:
         format_sql: true
-        globally_quoted_identifiers: true
+        globally_quoted_identifiers: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
   datasource:
     driver-class-name: org.h2.Driver
-    url: "jdbc:h2:mem:GRADE;MODE=MYSQL;DB_CLOSE_DELAY=-1"
+    url: "jdbc:h2:~/search"
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
 
 management:
   endpoints:

--- a/search-core/src/main/java/com/james/core/entity/History.java
+++ b/search-core/src/main/java/com/james/core/entity/History.java
@@ -1,0 +1,24 @@
+package com.james.core.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@Entity
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class History extends BaseEntity {
+
+    @Id
+    @ToString.Exclude
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @ToString.Exclude
+    /* 검색 */
+    private Search search;
+}

--- a/search-core/src/main/java/com/james/core/entity/History.java
+++ b/search-core/src/main/java/com/james/core/entity/History.java
@@ -7,7 +7,6 @@ import javax.persistence.*;
 @Getter
 @Setter
 @Entity
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class History extends BaseEntity {

--- a/search-core/src/main/java/com/james/core/entity/Shedlock.java
+++ b/search-core/src/main/java/com/james/core/entity/Shedlock.java
@@ -1,0 +1,26 @@
+package com.james.core.entity;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Entity
+public class Shedlock {
+
+    @Id
+    @Column(length = 64)
+    private String name;
+
+    @Column
+    private String lockedBy;
+
+    @CreatedDate
+    @Column(length = 3)
+    private LocalDateTime lockedAt;
+
+    @Column(length = 3)
+    private LocalDateTime lockUntil;
+}

--- a/search-core/src/main/java/com/james/core/repository/HistoryRepository.java
+++ b/search-core/src/main/java/com/james/core/repository/HistoryRepository.java
@@ -1,14 +1,16 @@
 package com.james.core.repository;
 
 import com.james.core.entity.History;
-import com.james.core.entity.Search;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 
 @Repository
 public interface HistoryRepository extends JpaRepository<History, String> {
 
-    Long countBySearch(Search search);
+    List<History> findByCreatedAtBefore(LocalDateTime localDateTime);
 
 }

--- a/search-core/src/main/java/com/james/core/repository/HistoryRepository.java
+++ b/search-core/src/main/java/com/james/core/repository/HistoryRepository.java
@@ -1,0 +1,14 @@
+package com.james.core.repository;
+
+import com.james.core.entity.History;
+import com.james.core.entity.Search;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface HistoryRepository extends JpaRepository<History, String> {
+
+    Long countBySearch(Search search);
+
+}

--- a/search-core/src/main/java/com/james/core/repository/SearchRepository.java
+++ b/search-core/src/main/java/com/james/core/repository/SearchRepository.java
@@ -17,5 +17,10 @@ public interface SearchRepository extends JpaRepository<Search, String> {
     @Query("update Search t1 set t1.callCount=t1.callCount+1 where t1.id=:id")
     void increaseCallCount(Long id);
 
+    @Modifying
+    @Transactional
+    @Query("update Search t1 set t1.callCount=t1.callCount-:count where t1.id=:id")
+    void decreaseCallCount(Long id, Long count);
+
     List<Search> findTop10ByOrderByCallCountDesc();
 }

--- a/search-core/src/test/java/com/james/core/entity/HistoryEntityTest.java
+++ b/search-core/src/test/java/com/james/core/entity/HistoryEntityTest.java
@@ -1,0 +1,40 @@
+package com.james.core.entity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HistoryEntityTest {
+
+    public static final long TEST_ID = 1L;
+    private static Search TEST_SEARCH;
+
+    @BeforeEach
+    void init() {
+        TEST_SEARCH = new Search();
+    }
+
+    @Nested
+    @DisplayName("History 엔티티는")
+    class DescribeHistoryEntity {
+
+        @Nested
+        @DisplayName("정상적인 데이터로 생성자가 호출되면")
+        class ContextWithConstructor {
+
+            @Test
+            @DisplayName("전달받은 데이터를 가진 History 객체가 생성된다.")
+            void itReturnsHistory() {
+
+                History history = new History(TEST_ID, TEST_SEARCH);
+
+                assertEquals(TEST_ID, history.getId());
+                assertEquals(TEST_SEARCH, history.getSearch());
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
- 인기검색어 자동갱신 기능을 위한 스케쥴러 추가

## History
- [x] 인기검색어 관리를 위한 History 관련 코드 복원
- [x] Schedule 사용하여 5분에 한 번씩 검색된지 15분 이상 된 History 삭제.
- [x] 삭제한 History 수만큼 Search의 callCount 감소
- [x] 멀티 서버일 경우 스케쥴러 중복이므로 Shedlock 추가
- [x] Shedlock을 위한 shedlock Entity를 만들어 JPA를 통해 테이블 자동 생성하도록 추가
- [x] H2 Console UI enable
